### PR TITLE
Update: Force bash in "Collect privileged binaries" task

### DIFF
--- a/roles/hardening/tasks/auditd.yml
+++ b/roles/hardening/tasks/auditd.yml
@@ -26,6 +26,8 @@
     mode: '0600'
 
 - name: Collect privileged binaries
+  args:
+    executable: /bin/bash
   shell: |
     set -o pipefail
     for i in  $(df | grep '^/dev' | awk '{ print $NF }'); do


### PR DESCRIPTION
Hello,

I've got error running playbook. Solved by
```
  args:
    executable: /bin/bash
```
https://github.com/ansible-community/ansible-lint/issues/497

https://stackoverflow.com/questions/35352955/set-illegal-option-on-one-host-but-not-the-other